### PR TITLE
Add items from dialog with any trait correctly

### DIFF
--- a/WishList/src/dialog/dialogs.lua
+++ b/WishList/src/dialog/dialogs.lua
@@ -1716,7 +1716,7 @@ function WL.buildSetItemDataFromAddItemDialog(comboItemType, comboArmorOrWeaponT
     selectedCharData.nameClean  = charNameClean
     selectedCharData.class      = charClass
 
-    local items = WL.getSetItemsByCriteria(WL.currentSetId, itemTypeId, armorOrWeaponTypeId, traitId, slotId, qualityId, false)
+    local items = WL.getSetItemsByCriteria(WL.currentSetId, itemTypeId, armorOrWeaponTypeId, traitId, slotId, qualityId, traitId == WISHLIST_TRAIT_TYPE_ALL)
 
     return items, selectedCharData
 end


### PR DESCRIPTION
Adding from the dialog adds all traits seperately even if any trait option is selected, so this changes this behaviour to add the item as one instead of with all traits.